### PR TITLE
Option To Skip/Exclude Classes With __DIR__ Or __FILE__

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You use the bin/classpreloader.php compile command with a few command line flags
 
 `--output`: The path to the file to store the compiled PHP code. If the directory does not exist, the tool will attempt to create it.
 
+`--skip_dir_file`: (no value) Skip files with "__DIR__" or "__FILE__" to make the cache portable.
+
 `--fix_dir`: (defaults to 1) Set to 0 to not replace "__DIR__" constants with the actual directory of the original file.
 
 `--fix_file`: (defaults to 1) Set to 0 to not replace "__FILE__" constants with the actual location of the original file.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "bin": ["classpreloader.php"],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }

--- a/src/Command/PreCompileCommand.php
+++ b/src/Command/PreCompileCommand.php
@@ -3,10 +3,10 @@
 namespace ClassPreloader\Command;
 
 use ClassPreloader\Config;
+use ClassPreloader\Exception\SkipFileException;
 use ClassPreloader\Parser\DirVisitor;
 use ClassPreloader\Parser\FileVisitor;
 use ClassPreloader\Parser\NodeTraverser;
-use ClassPreloader\Exception\SkipFileException;
 use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
@@ -261,17 +261,17 @@ EOF
         // Write the first line of the output
         fwrite($handle, "<?php\n");
         $output->writeln('> Compiling classes');
-        
+
         $count = 0;
         $countSkipped = 0;
         foreach ($files as $file) {
-            $count ++;
+            $count++;
             try {
                 $code = $this->getCode($file);
                 $this->output->writeln('- Writing ' . $file);
                 fwrite($handle, $code . "\n");
             } catch (SkipFileException $ex) {
-                $countSkipped ++;
+                $countSkipped++;
                 $this->output->writeln('- Skipping ' . $file);
             }
         }

--- a/src/Exception/SkipFileException.php
+++ b/src/Exception/SkipFileException.php
@@ -1,0 +1,11 @@
+<?php
+namespace ClassPreloader\Exception;
+
+use Exception;
+
+/**
+ * Abstract node visitor used to track the filename
+ */
+class SkipFileException extends Exception
+{
+}

--- a/src/Exception/SkipFileException.php
+++ b/src/Exception/SkipFileException.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace ClassPreloader\Exception;
 
 use Exception;
 
 /**
- * Abstract node visitor used to track the filename
+ * This is the skip file exception class.
  */
 class SkipFileException extends Exception
 {
+    //
 }

--- a/src/Parser/DirVisitor.php
+++ b/src/Parser/DirVisitor.php
@@ -2,6 +2,7 @@
 
 namespace ClassPreloader\Parser;
 
+use ClassPreloader\Exception\SkipFileException;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\String;
@@ -13,6 +14,13 @@ use PhpParser\Node\Scalar\String;
  */
 class DirVisitor extends AbstractNodeVisitor
 {
+    protected $throwException = false;
+    
+    public function __construct($mode = false)
+    {
+        $this->throwException = $mode;
+    }
+    
     /**
      * Enter and modify the node.
      *
@@ -23,6 +31,10 @@ class DirVisitor extends AbstractNodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Dir) {
+            if ($this->throwException === true) {
+                throw new SkipFileException('__DIR__ constant found, skipping...');
+            }
+            
             return new String($this->getDir());
         }
     }

--- a/src/Parser/DirVisitor.php
+++ b/src/Parser/DirVisitor.php
@@ -14,13 +14,25 @@ use PhpParser\Node\Scalar\String;
  */
 class DirVisitor extends AbstractNodeVisitor
 {
-    protected $throwException = false;
-    
-    public function __construct($mode = false)
+    /**
+     * Should we skip the file if it contains a dir constant?
+     *
+     * @var bool
+     */
+    protected $skip = false;
+
+    /**
+     * Create a new directory visitor.
+     *
+     * @param bool mode
+     *
+     * @return void
+     */
+    public function __construct($skip = false)
     {
-        $this->throwException = $mode;
+        $this->skip = $skip;
     }
-    
+
     /**
      * Enter and modify the node.
      *
@@ -31,10 +43,10 @@ class DirVisitor extends AbstractNodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Dir) {
-            if ($this->throwException === true) {
+            if ($this->skip) {
                 throw new SkipFileException('__DIR__ constant found, skipping...');
             }
-            
+
             return new String($this->getDir());
         }
     }

--- a/src/Parser/DirVisitor.php
+++ b/src/Parser/DirVisitor.php
@@ -24,7 +24,7 @@ class DirVisitor extends AbstractNodeVisitor
     /**
      * Create a new directory visitor.
      *
-     * @param bool mode
+     * @param bool $skip
      *
      * @return void
      */

--- a/src/Parser/FileVisitor.php
+++ b/src/Parser/FileVisitor.php
@@ -24,7 +24,7 @@ class FileVisitor extends AbstractNodeVisitor
     /**
      * Create a new file visitor.
      *
-     * @param bool mode
+     * @param bool $skip
      *
      * @return void
      */

--- a/src/Parser/FileVisitor.php
+++ b/src/Parser/FileVisitor.php
@@ -2,6 +2,7 @@
 
 namespace ClassPreloader\Parser;
 
+use ClassPreloader\Exception\SkipFileException;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\MagicConst\File;
 use PhpParser\Node\Scalar\String;
@@ -13,6 +14,13 @@ use PhpParser\Node\Scalar\String;
  */
 class FileVisitor extends AbstractNodeVisitor
 {
+    protected $throwException = false;
+    
+    public function __construct($mode = false)
+    {
+        $this->throwException = $mode;
+    }
+    
     /**
      * Enter and modify the node.
      *
@@ -23,6 +31,10 @@ class FileVisitor extends AbstractNodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof File) {
+            if ($this->throwException === true) {
+                throw new SkipFileException('__FILE__ constant found, skipping...');
+            }
+            
             return new String($this->getFilename());
         }
     }

--- a/src/Parser/FileVisitor.php
+++ b/src/Parser/FileVisitor.php
@@ -14,13 +14,25 @@ use PhpParser\Node\Scalar\String;
  */
 class FileVisitor extends AbstractNodeVisitor
 {
-    protected $throwException = false;
-    
-    public function __construct($mode = false)
+    /**
+     * Should we skip the file if it contains a file constant?
+     *
+     * @var bool
+     */
+    protected $skip = false;
+
+    /**
+     * Create a new file visitor.
+     *
+     * @param bool mode
+     *
+     * @return void
+     */
+    public function __construct($skip = false)
     {
-        $this->throwException = $mode;
+        $this->skip = $skip;
     }
-    
+
     /**
      * Enter and modify the node.
      *
@@ -31,10 +43,10 @@ class FileVisitor extends AbstractNodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof File) {
-            if ($this->throwException === true) {
+            if ($this->skip) {
                 throw new SkipFileException('__FILE__ constant found, skipping...');
             }
-            
+
             return new String($this->getFilename());
         }
     }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -42,7 +42,18 @@ class CommandTest extends PHPUnit_Framework_TestCase
 - Writing $bar
 - Writing $foo
 > Compiled loader written to $out
-- 0 kb
+- Files: 2/2 (skipped: 0)
+- Filesize: 0 kb
+EOT;
+        $expectedSkip = <<<EOT
+> Loading configuration file
+- Found 1 files
+> Compiling classes
+- Skipping $bar
+- Skipping $foo
+> Compiled loader written to $out
+- Files: 0/2 (skipped: 2)
+- Filesize: 0 kb
 EOT;
 
         $first = <<<EOT
@@ -175,6 +186,15 @@ EOT;
                 ),
                 $expected,
                 $last,
+            ),
+            array(
+                array(
+                    '--config'   => __DIR__ . DIRECTORY_SEPARATOR . 'classlist.php',
+                    '--output'   => $out,
+                    '--skip_dir_file' => true,
+                ),
+                $expectedSkip,
+                '<?php',
             ),
         );
     }


### PR DESCRIPTION
This is to allow for optional portability.

---
Replaces #40 and #38. Refs #37. // cc @ThaDafinser.